### PR TITLE
audio codec param to -c:a

### DIFF
--- a/src/ffmpegOutput.js
+++ b/src/ffmpegOutput.js
@@ -33,7 +33,7 @@ class FfmpegOutput extends FfmpegBase {
 		if (!audioCodec) {
 			this._options['-c:a'] = ['-an'];
 		} else {
-			this._options['-c:a'] = ['-c:v', audioCodec];
+			this._options['-c:a'] = ['-c:a', audioCodec];
 		}
 
 		return this;


### PR DESCRIPTION
in ffmpegOutput.js, the audioCodec() option is wrong